### PR TITLE
Add text editor specific gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Individual editor specific
+.vscode/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,7 @@ dmypy.json
 # Individual editor specific
 .vscode/
 .idea/
+
+# Mac specific
+**/.DS_Store
+.DS_Store


### PR DESCRIPTION
Add `.gitignore` VSCode and JetBrain environments. We don't want to overwrite our individual editor preferences.