### PR TITLE
Add way to see friends

### DIFF
--- a/endpoints.txt
+++ b/endpoints.txt
@@ -63,6 +63,21 @@ POST /authors/{AUTHOR_UUID}/posts/{POST_UUID}/comments
 FOLLOWS
 ===========================
 
+### TO GET ALL FOLLOWERS
+GET /authors/{AUTHOR_UUID}/followers
+
+### TO CREATE A FOLLOW REQUEST
+```POST /authors/{AUTHOR_UUID}/followers/```
+
+Note that this request assumes that the data is:
+```
+{
+    "actor": {CURRENT_USER},
+    "object": {AUTHOR_UUID}
+    "has_accepted": false
+}
+```
+
 ### TO GET ALL OUTGOING FOLLOW REQUESTS
 ```GET /follows/outgoing/```
 
@@ -102,21 +117,6 @@ Note that a user can only delete a request if they are either the actor or objec
 
 Note that a user can only delete a request if they are either the actor or object.
 
-### TO GET ALL FOLLOWERS
-GET /authors/{AUTHOR_UUID}/followers
-
-### TO CREATE A FOLLOW REQUEST
-```POST /authors/{AUTHOR_UUID}/followers/```
-
-Note that this request assumes that the data is:
-```
-{
-    "actor": {CURRENT_USER},
-    "object": {AUTHOR_UUID}
-    "has_accepted": false
-}
-```
-
 --------------------------
 AUTHORS
 ==========================
@@ -128,7 +128,89 @@ AUTHORS
 
 
 --------------------------
-FRIENDS
+REAL FRIENDS
 ==========================
-### GET ALL FRIENDS
-```GET /authors/{AUTHOR_UUID}/friends/```
+### GET ALL REAL FRIENDS
+```GET /authors/{AUTHOR_UUID}/real-friends/```
+
+----------------------------------------------------
+FRONTEND GUIDE ON HOW TO ACCEPT FRIEND REQUESTS
+====================================================
+
+User B wants to follow User A.
+
+1. Logged in User B will request to follow User A
+```POST /authors/{USER_A_ID}/followers/```
+
+Note: You don't need a JSON body for this one, but this creates this object in the database:
+```
+{
+    "type", "Follow"
+    "id": {FOLLOW_ID}, # generated
+    "actor": {USER_B}, # assumed User B
+    "object": {USER_A}
+    "has_accepted": false
+}
+```
+
+2. User A logs in and checks the pending follow request they have.
+```GET /follows/incoming/```
+
+The client receives a list of follow requests, and it's the frontend's job to display this list.
+The object it receive looks like this.
+Note 1: This endpoint assumes that these are follow requests only for the logged in user (User A).
+```json
+{
+    "type": "followRequests",
+    [
+        {
+            "type", "Follow",
+            "id": {FOLLOW_ID},
+            "actor": {USER_B},
+            "object": {USER_A}
+            "has_accepted": false
+        },
+        {...},
+        ...
+    ],
+}
+```
+
+
+3. User A can respond to User B's follow request.
+
+3.A. If User A wants to accept the follow request.
+```
+PUT /follows/<FOLLOW_UUID>/
+{
+    "has_accepted": true, # <- User A has to explicitly say, yeah, I accept this request
+}
+```
+
+Note: PUT only works one-way. It cannot make a follower unfollow or decline a request.
+You have to DELETE.
+
+3.B. If User A wants to decline the follow request.
+```DELETE /follows/<FOLLOW_UUID>/```
+
+4. User B now follows User A. To check:
+
+4.A. Everyone, includingUser A and User B, can now see that User B now appears under User A's followers
+```GET /authors/{USER_A_ID}/followers/```
+
+This returns:
+```json
+{
+    "type": "followers",
+    "items": [
+        {USER B}
+    ]
+}
+```
+
+4.B. The follow request is now gone for User A if you look at the follow request endpoint
+```GET /follows/incoming/```
+
+4.B. The follow request is now gone for User B if you look at the follow request endpoint
+```GET /follows/outgoing/```
+Note: not really in the user story

--- a/endpoints.txt
+++ b/endpoints.txt
@@ -125,3 +125,10 @@ AUTHORS
 
 ### GET A SPECIFIC AUTHOR
 ```GET /authors/{AUTHOR_UUID}/```
+
+
+--------------------------
+FRIENDS
+==========================
+### GET ALL FRIENDS
+```GET /authors/{AUTHOR_UUID}/friends/```

--- a/mysocial/follow/follow_util.py
+++ b/mysocial/follow/follow_util.py
@@ -1,5 +1,4 @@
 import logging
-from itertools import chain
 
 from authors.models import Author
 from follow.models import Follow
@@ -53,8 +52,8 @@ class FollowUtil:
         # then, intersect at A and B, those are real friends
         follower_ids = Follow.objects.values_list('actor', flat=True).filter(target=actor, has_accepted=True)
         following_ids = Follow.objects.values_list('target', flat=True).filter(actor=actor, has_accepted=True)
-        # reference: https://stackoverflow.com/a/48327252/17836168
-        friend_ids = list(chain(following_ids, follower_ids))
+        # reference: https://stackoverflow.com/a/6369558/17836168
+        friend_ids = set(follower_ids).intersection(following_ids)
         return Author.objects.filter(official_id__in=friend_ids)
 
     @staticmethod

--- a/mysocial/follow/follow_util.py
+++ b/mysocial/follow/follow_util.py
@@ -1,0 +1,69 @@
+import logging
+from itertools import chain
+
+from authors.models import Author
+from follow.models import Follow
+
+logger = logging.getLogger(__name__)
+
+
+class FollowUtil:
+    @staticmethod
+    def get_followers(target: Author):
+        """
+        Get all followers for target Author
+
+        :param target:
+        :return:
+
+        Remember to catch errors!
+        """
+        follow_ids = Follow.objects.values_list('actor', flat=True).filter(target=target, has_accepted=True)
+        return Author.objects.filter(official_id__in=follow_ids)
+
+    @staticmethod
+    def are_followers(follower: Author, target: Author):
+        """
+        Checks if follower Author follows target Author
+
+        :param follower:
+        :param target:
+        :return:
+        """
+        try:
+            Follow.objects.get(actor=follower, target=target, has_accepted=True)
+            return True  # did not return a does not exist error
+        except Follow.DoesNotExist:
+            return False
+        except Exception as e:
+            logger.error(f"FollowUtil: are_real_friends: unknown error: {e}")
+
+    @staticmethod
+    def get_real_friends(actor: Author):
+        """
+        Get all real friends
+
+        :param actor:
+        :return:
+
+        Remember to catch errors!
+        """
+        # reference: https://stackoverflow.com/a/9727050/17836168
+        # to get real friends, get all my followers (A) and get everyone who follows me (B)
+        # then, intersect at A and B, those are real friends
+        follower_ids = Follow.objects.values_list('actor', flat=True).filter(target=actor, has_accepted=True)
+        following_ids = Follow.objects.values_list('target', flat=True).filter(actor=actor, has_accepted=True)
+        # reference: https://stackoverflow.com/a/48327252/17836168
+        friend_ids = list(chain(following_ids, follower_ids))
+        return Author.objects.filter(official_id__in=friend_ids)
+
+    @staticmethod
+    def are_real_friends(actor: Author, target: Author):
+        try:
+            Follow.objects.get(actor=actor, target=target, has_accepted=True)
+            Follow.objects.get(actor=target, target=actor, has_accepted=True)
+            return True  # did not return a does not exist error
+        except Follow.DoesNotExist:
+            return False
+        except Exception as e:
+            logger.error(f"FollowUtil: are_real_friends: unknown error: {e}")

--- a/mysocial/follow/serializers/follow_serializer.py
+++ b/mysocial/follow/serializers/follow_serializer.py
@@ -18,4 +18,4 @@ class FollowRequestSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Follow
-        fields = ('type', 'summary', 'has_accepted', 'object', 'actor')
+        fields = ('type', 'id', 'summary', 'has_accepted', 'object', 'actor')

--- a/mysocial/follow/urls.py
+++ b/mysocial/follow/urls.py
@@ -11,5 +11,5 @@ urlpatterns = [
     path(f'{app_name}/outgoing/', views.OutgoingRequestView.as_view()),
     path(f'{app_name}/<int:follow_id>/', views.IndividualRequestView.as_view()),
     path(f'{authors_app_name}/<uuid:author_id>/followers/', views.FollowersView.as_view()),
-    path(f'{authors_app_name}/<uuid:author_id>/friends/', views.RealFriendsView.as_view()),
+    path(f'{authors_app_name}/<uuid:author_id>/real-friends/', views.RealFriendsView.as_view()),
 ]

--- a/mysocial/follow/urls.py
+++ b/mysocial/follow/urls.py
@@ -9,6 +9,7 @@ app_name = 'follows'
 urlpatterns = [
     path(f'{app_name}/incoming/', views.IncomingRequestView.as_view()),
     path(f'{app_name}/outgoing/', views.OutgoingRequestView.as_view()),
-    path(f'{app_name}/<int:follow_id>', views.IndividualRequestView.as_view()),
-    path(f'{authors_app_name}/<uuid:author_id>/followers', views.FollowersView.as_view()),
+    path(f'{app_name}/<int:follow_id>/', views.IndividualRequestView.as_view()),
+    path(f'{authors_app_name}/<uuid:author_id>/followers/', views.FollowersView.as_view()),
+    path(f'{authors_app_name}/<uuid:author_id>/friends/', views.RealFriendsView.as_view()),
 ]

--- a/mysocial/follow/views.py
+++ b/mysocial/follow/views.py
@@ -30,7 +30,10 @@ class OutgoingRequestView(GenericAPIView):
         data, err = PaginationHelper.paginate_serialized_data(request, serializers.data)
         if err is not None:
             return HttpResponseNotFound()
-        return Response(data=data)
+        return Response(data={
+            'type': 'followRequests',
+            'items': data,
+        })
 
 
 class IncomingRequestView(GenericAPIView):
@@ -45,7 +48,10 @@ class IncomingRequestView(GenericAPIView):
         data, err = PaginationHelper.paginate_serialized_data(request, serializers.data)
         if err is not None:
             return HttpResponseNotFound()
-        return Response(data=data)
+        return Response(data={
+            'type': 'followRequests',
+            'items': data,
+        })
 
 
 class IndividualRequestView(GenericAPIView):
@@ -81,7 +87,7 @@ class IndividualRequestView(GenericAPIView):
         """
         try:
             follow = Follow.objects.get(id=follow_id)
-            if follow.target != request.user and follow.actor != request.user:
+            if follow.target != request.user:
                 # Only the two accounts should be able to delete an account
                 # Returning not found due to security concerns
                 return HttpResponseNotFound()


### PR DESCRIPTION
Closes #35 

## Changes
- Refactor some logic into `FollowUtil` so we can use it for things like showing specific posts to real friends only and so on...
  - Check if follower
  - Check if real friends
  - Get all followers
  - Get all real friends
- Add RealFriendsView

## Screenshots
Current following status of users
![image](https://user-images.githubusercontent.com/21351900/197374281-0d621b46-37cf-42c2-8829-f21804aa4b41.png)


Being friends require bidirectional follows
![image](https://user-images.githubusercontent.com/21351900/197374308-85d54c27-1698-4ea1-948c-88c694003c44.png)

