### PR TITLE
Refactor removing __init__

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ https://stackoverflow.com/questions/3805958/how-to-delete-a-record-in-django-mod
 https://stackoverflow.com/questions/12615154/how-to-get-the-currently-logged-in-users-user-id-in-django --> will probably use to authenticate
 - you can change how you're logged in based on 127.0.0.1:8000/admin
 https://stackoverflow.com/questions/31173324/django-rest-framework-update-field
+https://stackoverflow.com/questions/15859156/python-how-to-convert-a-valid-uuid-from-string-to-uuid
 https://stackoverflow.com/questions/43859053/django-rest-framework-assertionerror-fix-your-url-conf-or-set-the-lookup-fi
 https://stackoverflow.com/questions/62381855/how-to-update-model-objects-only-one-field-data-when-doing-serializer-save
 https://stackoverflow.com/questions/35024781/create-or-update-with-put-in-django-rest-framework

--- a/mysocial/authors/admin.py
+++ b/mysocial/authors/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Author
+from authors.models.author import Author
 
 
 class AuthorAdmin(admin.ModelAdmin):

--- a/mysocial/authors/models/__init__.py
+++ b/mysocial/authors/models/__init__.py
@@ -1,1 +1,0 @@
-from .author import Author

--- a/mysocial/authors/serializers/author_serializer.py
+++ b/mysocial/authors/serializers/author_serializer.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
-from authors.models import Author
+
+from authors.models.author import Author
 
 
 class AuthorSerializer(serializers.ModelSerializer):

--- a/mysocial/authors/tests.py
+++ b/mysocial/authors/tests.py
@@ -1,8 +1,8 @@
 from unittest import skip
-from django.test import TestCase
-from django.test import Client
 
-from authors.models import Author
+from django.test import TestCase
+
+from authors.models.author import Author
 
 
 class TestAuthorView(TestCase):

--- a/mysocial/authors/views.py
+++ b/mysocial/authors/views.py
@@ -5,9 +5,9 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from authors.models import Author
+from authors.models.author import Author
 from authors.serializers.author_serializer import AuthorSerializer
-from common import PaginationHelper
+from common.pagination_helper import PaginationHelper
 
 logger = logging.getLogger(__name__)
 

--- a/mysocial/comment/tests.py
+++ b/mysocial/comment/tests.py
@@ -2,7 +2,7 @@ from rest_framework.test import APITestCase
 from rest_framework import status
 from post.models import Post
 from comment.models import Comment, ContentType
-from authors.models import Author
+from authors.models.author import Author
 from django.utils import timezone
 import logging
 import datetime

--- a/mysocial/comment/views.py
+++ b/mysocial/comment/views.py
@@ -3,7 +3,7 @@ from django.http.response import HttpResponse, HttpResponseNotFound
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.request import Request
-from authors.models import Author
+from authors.models.author import Author
 from comment.serializers import CommentSerializer, CreateCommentSerializer
 from .models import Comment
 from post.models import Post

--- a/mysocial/common/__init__.py
+++ b/mysocial/common/__init__.py
@@ -1,2 +1,0 @@
-from .pagination_helper import PaginationHelper
-from .test_helper import TestHelper

--- a/mysocial/common/test_helper.py
+++ b/mysocial/common/test_helper.py
@@ -1,4 +1,4 @@
-from authors.models import Author
+from authors.models.author import Author
 
 
 class TestHelper:

--- a/mysocial/follow/follow_util.py
+++ b/mysocial/follow/follow_util.py
@@ -1,6 +1,6 @@
 import logging
 
-from authors.models import Author
+from authors.models.author import Author
 from follow.models import Follow
 
 logger = logging.getLogger(__name__)

--- a/mysocial/follow/tests/base_test_follower_view.py
+++ b/mysocial/follow/tests/base_test_follower_view.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from common import TestHelper
+from common.test_helper import TestHelper
 from follow.models import Follow
 
 
@@ -26,6 +26,6 @@ class BaseTestFollowerView(TestCase):
 
             Follow.objects.create(actor=oomfie, target=self.target, has_accepted=has_accepted)
 
-        self.follower_names = map(lambda f: f.display_name, self.followers)
-        self.non_follower_names = map(lambda f: f.display_name, self.non_followers)
+        self.follower_names = list(map(lambda f: f.display_name, self.followers))
+        self.non_follower_names = list(map(lambda f: f.display_name, self.non_followers))
         self.client.force_login(self.target)

--- a/mysocial/follow/tests/test_followers_view.py
+++ b/mysocial/follow/tests/test_followers_view.py
@@ -1,7 +1,7 @@
 from django.db import transaction
 from django.test import TestCase
 
-from common import TestHelper
+from common.test_helper import TestHelper
 from follow.models import Follow
 from follow.tests.base_test_follower_view import BaseTestFollowerView
 

--- a/mysocial/follow/views.py
+++ b/mysocial/follow/views.py
@@ -12,9 +12,9 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from authors.models import Author
+from authors.models.author import Author
 from authors.serializers.author_serializer import AuthorSerializer
-from common import PaginationHelper
+from common.pagination_helper import PaginationHelper
 from follow.follow_util import FollowUtil
 from follow.models import Follow
 from follow.serializers.follow_serializer import FollowRequestSerializer

--- a/mysocial/post/tests.py
+++ b/mysocial/post/tests.py
@@ -1,7 +1,7 @@
 from rest_framework.test import APITestCase
 from rest_framework import status
 from post.models import Post, Visibility
-from authors.models import Author
+from authors.models.author import Author
 from django.utils import timezone
 import logging, uuid
 import datetime

--- a/mysocial/post/views.py
+++ b/mysocial/post/views.py
@@ -4,12 +4,12 @@ from rest_framework.response import Response
 from rest_framework.request import Request
 from .serializer import PostSerializer, CreatePostSerializer
 from django.core.paginator import Paginator
-from authors.models import Author
+from authors.models.author import Author
 from .models import Post, Visibility
 from rest_framework import status
 import logging, json
 from urllib.request import urlopen
-from common import PaginationHelper
+from common.pagination_helper import PaginationHelper
 
 logger = logging.getLogger("mylogger")
 

--- a/mysocial/tests.sh
+++ b/mysocial/tests.sh
@@ -1,0 +1,4 @@
+for p in "authors" "comment" "common" "follow" "post" "tokens"; do
+  # from https://unix.stackexchange.com/a/589382
+  python manage.py test $p || break
+done

--- a/mysocial/tests.sh
+++ b/mysocial/tests.sh
@@ -1,3 +1,5 @@
+# To run, `bash tests.sh`
+
 for p in "authors" "comment" "common" "follow" "post" "tokens"; do
   # from https://unix.stackexchange.com/a/589382
   python manage.py test $p || break

--- a/mysocial/tokens/tests.py
+++ b/mysocial/tokens/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from rest_framework.authtoken.models import Token
 
-from authors.models import Author
+from authors.models.author import Author
 
 
 class TestObtainCookieAuthToken(TestCase):


### PR DESCRIPTION
This is a chain of PRs #52 and #56

## Changes
- Removed `__init__`, changing all the import names for authors, common, and follows
- Add bash script that runs all the tests for command line testing

## Testing
Run all packages with:
```shell
bash tests.sh # windows; don't know in mac

sh tests.sh # mac?
```

which is equivalent to:
```shell
python manage.py test authors
python manage.py test comment
python manage.py test common
python manage.py test follow
python manage.py test post
python manage.py test tokens
```