### PR TITLE
Support mirror database

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,41 @@ Windows Instruction:
 
 Continue from step 8
 
+## Mirror instance
+
+This is a setup on how to run another Django server in a different port
+
+### Postgres
+
+These instructions are in Windows! Inside `psql`:
+
+1. `CREATE DATABASE mysocialdb_mirror;`
+2. `\connect mysocialdb_mirror`
+3. `ALTER ROLE mysocialuser CREATEDB;`
+   - Note: if you followed the initial step of making a database, you should have mysocialuser already
+4. `GRANT ALL ON SCHEMA public TO mysocialuser; GRANT ALL ON SCHEMA public TO public;`
+   - Schema public already exists!
+
+### Migration
+
+Migration is slightly different!
+
+```bash
+python manage.py migrate --settings mysocial.settings.local_mirror
+```
+
+### Running your mirror server
+
+Then, to run your mirror server:
+
+```bash
+python manage.py runserver --settings mysocial.settings.local_mirror 8080
+```
+
+Note:
+- The port number 8080 doesn't matter.
+- The port number being the last argument matters, though!
+
 You must run the postgres database as you're running the server!
 References:
 Amanda

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ python manage.py runserver --settings mysocial.settings.local_mirror 8080
 ```
 
 Note:
-- The port number 8080 doesn't matter.
+- The port 8080 matters because that's the node we want to connect to based on NODE_CREDENTIALS. See RemoteUtils.py.
 - The port number being the last argument matters, though!
 
 You must run the postgres database as you're running the server!

--- a/mysocial/authors/serializers/author_serializer.py
+++ b/mysocial/authors/serializers/author_serializer.py
@@ -35,8 +35,10 @@ class AuthorSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_host(model: Author) -> str:
-        # todo(turnip): if remote node: use host
-        return base.CURRENT_DOMAIN
+        if model.host == '':
+            return base.CURRENT_DOMAIN
+
+        return model.host
 
     def to_internal_value(self, data: dict) -> Author:
         """

--- a/mysocial/mysocial/settings/local_mirror.py
+++ b/mysocial/mysocial/settings/local_mirror.py
@@ -1,0 +1,14 @@
+# DO NOT DELETE THE IMPORT BELOW EVEN IF UNUSED
+from mysocial.settings.local import *  # just override local
+# DO NOT DELETE THE IMPORT ABOVE EVEN IF UNUSED
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'mysocialdb_mirror',
+        'USER': 'mysocialuser',
+        'PASSWORD': 'password',
+        'HOST': 'localhost',
+        'PORT': '5432',
+    }
+}

--- a/mysocial/remote_nodes/local_default.py
+++ b/mysocial/remote_nodes/local_default.py
@@ -1,0 +1,5 @@
+from remote_nodes.node_config_base import NodeConfigBase
+
+
+class LocalDefault(NodeConfigBase):
+    domain = '127.0.0.1:8000'

--- a/mysocial/remote_nodes/local_mirror.py
+++ b/mysocial/remote_nodes/local_mirror.py
@@ -1,0 +1,5 @@
+from remote_nodes.node_config_base import NodeConfigBase
+
+
+class LocalMirror(NodeConfigBase):
+    domain = '127.0.0.1:8080'

--- a/mysocial/remote_nodes/remote_util.py
+++ b/mysocial/remote_nodes/remote_util.py
@@ -51,9 +51,10 @@ class RemoteUtil:
         Setup all remote node configs and logic
         """
         # special remote node configs if you're running locally
-        # you may add your node here or via the REMOTE_NODE_CREDENTIALS config (see docs/server.md)
+        # you may add (or even override) your node here or via the REMOTE_NODE_CREDENTIALS config (see docs/server.md)
+
         if '127.0.0.1' in base.CURRENT_DOMAIN:
-            base.REMOTE_NODE_CREDENTIALS.update({
+            local_credentials = {
                 '127.0.0.1:8000': {
                     'username': 'local_default',
                     'password': 'local_default'
@@ -62,7 +63,11 @@ class RemoteUtil:
                     'username': 'local_mirror',
                     'password': 'local_mirror'
                 }
-            })
+            }
+            # tricky technique to make the user's config var override ours; useful for other teams!
+            local_credentials.update(base.REMOTE_NODE_CREDENTIALS)
+            # then set it back to our app's remote credentials
+            base.REMOTE_NODE_CREDENTIALS = local_credentials
 
         # setup remote config node type authors
         for host, credentials in base.REMOTE_NODE_CREDENTIALS.items():

--- a/mysocial/remote_nodes/remote_util.py
+++ b/mysocial/remote_nodes/remote_util.py
@@ -91,6 +91,9 @@ class RemoteUtil:
                 other_args.pop('username')
                 TestHelper.overwrite_author(username, other_args)
 
+        # This is where the endpoints and configs are added!
+        # When it's local (contains 127.0.0.1), we add 127.0.0.1:8000 and 127.0.0.1:8080
+        # Then, we add the endpoints, like turnip-oomfie-1.herokuapp.com (TurnipOomfie)
         additional_nodes = ()
         if '127.0.0.1' in base.CURRENT_DOMAIN:
             additional_nodes = (LocalDefault, LocalMirror)

--- a/mysocial/remote_nodes/remote_util.py
+++ b/mysocial/remote_nodes/remote_util.py
@@ -12,6 +12,8 @@ from remote_nodes.macewan import MacEwan
 from remote_nodes.potato_oomfie import PotatoOomfie
 from remote_nodes.turnip_oomfie import TurnipOomfie
 from remote_nodes.ualberta import UAlberta
+from remote_nodes.local_default import LocalDefault
+from remote_nodes.local_mirror import LocalMirror
 
 
 class RemoteUtil:
@@ -48,6 +50,20 @@ class RemoteUtil:
         """
         Setup all remote node configs and logic
         """
+        # special remote node configs if you're running locally
+        # you may add your node here or via the REMOTE_NODE_CREDENTIALS config (see docs/server.md)
+        if '127.0.0.1' in base.CURRENT_DOMAIN:
+            base.REMOTE_NODE_CREDENTIALS.update({
+                '127.0.0.1:8000': {
+                    'username': 'local_default',
+                    'password': 'local_default'
+                },
+                '127.0.0.1:8080': {
+                    'username': 'local_mirror',
+                    'password': 'local_mirror'
+                }
+            })
+
         # setup remote config node type authors
         for host, credentials in base.REMOTE_NODE_CREDENTIALS.items():
             node: Author = TestHelper.overwrite_node(credentials['username'], credentials['password'], host)
@@ -70,7 +86,7 @@ class RemoteUtil:
                 other_args.pop('username')
                 TestHelper.overwrite_author(username, other_args)
 
-        for config in (TurnipOomfie, PotatoOomfie, UAlberta, MacEwan):
+        for config in (TurnipOomfie, PotatoOomfie, UAlberta, MacEwan, LocalDefault, LocalMirror):
             base.REMOTE_CONFIG.update(config.create_dictionary_entry())
 
     @staticmethod

--- a/mysocial/remote_nodes/remote_util.py
+++ b/mysocial/remote_nodes/remote_util.py
@@ -50,9 +50,9 @@ class RemoteUtil:
         """
         Setup all remote node configs and logic
         """
+
         # special remote node configs if you're running locally
         # you may add (or even override) your node here or via the REMOTE_NODE_CREDENTIALS config (see docs/server.md)
-
         if '127.0.0.1' in base.CURRENT_DOMAIN:
             local_credentials = {
                 '127.0.0.1:8000': {
@@ -91,7 +91,10 @@ class RemoteUtil:
                 other_args.pop('username')
                 TestHelper.overwrite_author(username, other_args)
 
-        for config in (TurnipOomfie, PotatoOomfie, UAlberta, MacEwan, LocalDefault, LocalMirror):
+        additional_nodes = ()
+        if '127.0.0.1' in base.CURRENT_DOMAIN:
+            additional_nodes = (LocalDefault, LocalMirror)
+        for config in (TurnipOomfie, PotatoOomfie, UAlberta, MacEwan) + additional_nodes:
             base.REMOTE_CONFIG.update(config.create_dictionary_entry())
 
     @staticmethod


### PR DESCRIPTION
# Changes
- Add new settings.py for mirroring a database
- Add instruction about how to add a new database
- Add new default node credentials when running locally

# Screenshots

The encircled author here only exists in one database and not the other

![image](https://user-images.githubusercontent.com/21351900/201843167-2dd0d82a-933c-4647-ac40-b3e3b6b62661.png)

We can check out the other server's data via our endpoint using a query.
![image](https://user-images.githubusercontent.com/21351900/201846121-2380b763-6dd8-4422-bddc-27758ee308f9.png)

We can now follow someone locally!
![image](https://user-images.githubusercontent.com/21351900/201850766-ebd01049-22e8-4894-aacd-7dc63d0340fa.png)


*thank you so much team 14 ^^*